### PR TITLE
add link to repository and sections to About tab

### DIFF
--- a/about-project/index.html
+++ b/about-project/index.html
@@ -9,5 +9,11 @@
         <h2>Twitter Presidents</h2>
         <p>Placeholder text</p>
 
+        <h2>Data</h2>
+        <p>Placeholder text</p>
+
+        <h2>GitHub Repository</h2>
+        <p>This website was created as an assignment for the <a href="https://www.hks.harvard.edu/courses/programming-and-data-policymakers/" target="_blank"><b>DPI 691M: Programming and Data for Policymakers</b></a> course at Harvard Kennedy School. Its code is public and can be accessed in <a href="https://github.com/whuang26/Twitter-Presidents/" target="_blank">this repository</a>.</p>
+
     </body>
 </html>


### PR DESCRIPTION
Added Data and GitHub repository sections to "About the project" tab. Added brief description of the project and link to public repository.